### PR TITLE
Force numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ subgrounds==1.6.0
 web3==6.4.0
 pycoingecko==3.1.0
 pycountry==22.3.5
+numpy==1.26.4


### PR DESCRIPTION
Forces the pipelines to use numpy v1

The culprit:
![image](https://github.com/KlimaDAO/data-pipelines/assets/11857992/02829e3c-0668-4bcf-b7e2-03bf03e3a7df)
